### PR TITLE
testprojectlibrary: changed _build_capabilities method to use _ instead of key

### DIFF
--- a/TestProjectLibrary/TestProjectLibrary.py
+++ b/TestProjectLibrary/TestProjectLibrary.py
@@ -141,7 +141,7 @@ class TestProjectLibrary:
     def _build_capabilities(self, caps, browser_name):
         options = None
         if caps:
-            key, value = caps.popitem()
+            _, value = caps.popitem()
             try:
                 browser = value["browserName"]
             except Exception as e:


### PR DESCRIPTION
changed key in build_capabilities to _.

Signed-off-by: rantz <ran.tzur@testproject.io>